### PR TITLE
fix: 修复后端TypeScript类型错误

### DIFF
--- a/backend/src/routes/approvals.ts
+++ b/backend/src/routes/approvals.ts
@@ -92,7 +92,7 @@ router.get('/pending', authenticate, async (req: AuthRequest, res: Response) => 
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const approval = await approvalRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['applicant', 'approver']
     });
 
@@ -115,7 +115,7 @@ router.post('/:id/process', authenticate, async (req: AuthRequest, res: Response
   try {
     const { action, comment } = req.body; // action: approve/reject
     const approval = await approvalRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['applicant']
     });
 
@@ -159,7 +159,7 @@ router.post('/:id/process', authenticate, async (req: AuthRequest, res: Response
 router.post('/:id/cancel', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const approval = await approvalRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!approval) {

--- a/backend/src/routes/contracts.ts
+++ b/backend/src/routes/contracts.ts
@@ -81,7 +81,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const contract = await contractRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['customer', 'owner', 'creator', 'opportunity']
     });
 
@@ -170,7 +170,7 @@ router.post('/', authenticate, authorize('contract:create'), async (req: AuthReq
 router.put('/:id', authenticate, authorize('contract:update'), async (req: AuthRequest, res: Response) => {
   try {
     const contract = await contractRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!contract) {
@@ -214,7 +214,7 @@ router.put('/:id', authenticate, authorize('contract:update'), async (req: AuthR
 router.post('/:id/approve', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const contract = await contractRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['customer']
     });
 
@@ -267,7 +267,7 @@ router.post('/:id/approve', authenticate, async (req: AuthRequest, res: Response
 router.delete('/:id', authenticate, authorize('contract:delete'), async (req: AuthRequest, res: Response) => {
   try {
     const contract = await contractRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!contract) {

--- a/backend/src/routes/customers.ts
+++ b/backend/src/routes/customers.ts
@@ -89,7 +89,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const customer = await customerRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['owner', 'creator']
     });
 
@@ -151,7 +151,7 @@ router.post('/', authenticate, authorize('customer:create'), async (req: AuthReq
 router.put('/:id', authenticate, authorize('customer:update'), async (req: AuthRequest, res: Response) => {
   try {
     const customer = await customerRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!customer) {
@@ -193,7 +193,7 @@ router.put('/:id', authenticate, authorize('customer:update'), async (req: AuthR
 router.delete('/:id', authenticate, authorize('customer:delete'), async (req: AuthRequest, res: Response) => {
   try {
     const customer = await customerRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!customer) {

--- a/backend/src/routes/opportunities.ts
+++ b/backend/src/routes/opportunities.ts
@@ -90,7 +90,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const opportunity = await opportunityRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['customer', 'owner', 'presales']
     });
 
@@ -159,7 +159,7 @@ router.post('/', authenticate, authorize('opportunity:create'), async (req: Auth
 router.put('/:id', authenticate, authorize('opportunity:update'), async (req: AuthRequest, res: Response) => {
   try {
     const opportunity = await opportunityRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!opportunity) {
@@ -213,7 +213,7 @@ router.post('/:id/change-stage', authenticate, async (req: AuthRequest, res: Res
   try {
     const { stage } = req.body;
     const opportunity = await opportunityRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!opportunity) {
@@ -243,7 +243,7 @@ router.post('/:id/change-approval', authenticate, async (req: AuthRequest, res: 
   try {
     const { changeType, beforeContent, afterContent, reason } = req.body;
     const opportunity = await opportunityRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['customer']
     });
 
@@ -289,7 +289,7 @@ router.post('/:id/change-approval', authenticate, async (req: AuthRequest, res: 
 router.delete('/:id', authenticate, authorize('opportunity:delete'), async (req: AuthRequest, res: Response) => {
   try {
     const opportunity = await opportunityRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!opportunity) {

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -91,7 +91,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const project = await projectRepository().findOne({
-      where: { id: req.params.id },
+      where: { id: String(req.params.id) },
       relations: ['contract', 'contract.customer', 'manager', 'deputyManager', 'creator']
     });
 
@@ -172,7 +172,7 @@ router.post('/', authenticate, authorize('project:create'), async (req: AuthRequ
 router.put('/:id', authenticate, authorize('project:update'), async (req: AuthRequest, res: Response) => {
   try {
     const project = await projectRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!project) {
@@ -219,7 +219,7 @@ router.put('/:id', authenticate, authorize('project:update'), async (req: AuthRe
 router.post('/:id/approve', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const project = await projectRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!project) {
@@ -268,7 +268,7 @@ router.post('/:id/change-approval', authenticate, async (req: AuthRequest, res: 
   try {
     const { changeType, changeTitle, beforeContent, afterContent, reason } = req.body;
     const project = await projectRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!project) {
@@ -314,7 +314,7 @@ router.post('/:id/change-approval', authenticate, async (req: AuthRequest, res: 
 router.delete('/:id', authenticate, authorize('project:delete'), async (req: AuthRequest, res: Response) => {
   try {
     const project = await projectRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!project) {
@@ -341,7 +341,7 @@ router.delete('/:id', authenticate, authorize('project:delete'), async (req: Aut
 router.post('/:id/milestones', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const { name, description, planDate, deliverables } = req.body;
-    const project = await projectRepository().findOne({ where: { id: req.params.id } });
+    const project = await projectRepository().findOne({ where: { id: String(req.params.id) } });
 
     if (!project) {
       return res.status(404).json({ success: false, message: '项目不存在' });
@@ -378,7 +378,7 @@ router.post('/:id/milestones', authenticate, async (req: AuthRequest, res: Respo
 router.post('/:id/members', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const { userId, role, department, joinDate, workRatio } = req.body;
-    const project = await projectRepository().findOne({ where: { id: req.params.id } });
+    const project = await projectRepository().findOne({ where: { id: String(req.params.id) } });
 
     if (!project) {
       return res.status(404).json({ success: false, message: '项目不存在' });

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -73,7 +73,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
 router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const user = await userRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!user) {
@@ -146,7 +146,7 @@ router.post('/', authenticate, authorize('system:user:create'), async (req: Auth
 router.put('/:id', authenticate, authorize('system:user:update'), async (req: AuthRequest, res: Response) => {
   try {
     const user = await userRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!user) {
@@ -185,7 +185,7 @@ router.put('/:id', authenticate, authorize('system:user:update'), async (req: Au
 router.delete('/:id', authenticate, authorize('system:user:delete'), async (req: AuthRequest, res: Response) => {
   try {
     const user = await userRepository().findOne({
-      where: { id: req.params.id }
+      where: { id: String(req.params.id) }
     });
 
     if (!user) {


### PR DESCRIPTION
## 修复内容

修复了后端TypeScript编译错误（30个类型错误），将所有路由文件中的 `req.params.id` 转换为 `String` 类型，解决TypeORM FindOptionsWhere类型不匹配的问题。

## 修复的文件

- `backend/src/routes/users.ts`
- `backend/src/routes/customers.ts`
- `backend/src/routes/opportunities.ts`
- `backend/src/routes/contracts.ts`
- `backend/src/routes/projects.ts`
- `backend/src/routes/approvals.ts`

## 测试

- TypeScript编译通过 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)