### PR TITLE
fix: 添加Vite代理配置

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,14 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 修复内容

在 vite.config.ts 中添加代理配置，使前端能正确调用后端API

## 修改
- `frontend/vite.config.ts` - 添加 server.proxy 配置

## 测试
- 登录API调用验证成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)